### PR TITLE
Fixed project_id typo

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 :toc:
 :icons: font
 :source-highlighter: prettify
-:project_id: -gs-multi-module
+:project_id: gs-multi-module
 
 This guide shows you how to create a multi-module project with Spring Boot. The project
 will have a library jar and a main application that uses the library. You could also


### PR DESCRIPTION
From `-gs-multi-module` to `gs-multi-module`

Unable to clone due the the typo: https://spring.io/guides/gs/multi-module/#_how_to_complete_this_guide

![image](https://user-images.githubusercontent.com/4266087/86771538-fcefa000-c084-11ea-9ada-6fc2ba58b0f6.png)
