### PR TITLE
fix: using `com.example:library-complete` for complete case

### DIFF
--- a/complete/application/pom.xml
+++ b/complete/application/pom.xml
@@ -27,7 +27,7 @@
 		</dependency>
 		<dependency>
 			<groupId>com.example</groupId>
-			<artifactId>library</artifactId>
+			<artifactId>library-complete</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 


### PR DESCRIPTION

fix #45 