### PR TITLE
Upgrade library module to Spring Boot 3.3.0

### DIFF
--- a/complete/library/pom.xml
+++ b/complete/library/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.2</version>
+		<version>3.3.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>


### PR DESCRIPTION
This is exactly what I don't like about this setup: the Spring version needs to be incremented for every single module instead at one central place.